### PR TITLE
ci: add scaler to workflow tests

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,6 +1,6 @@
 name: Node.js unit tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test-all:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -3,7 +3,7 @@ name: Node.js unit tests
 on: [push, pull_request]
 
 jobs:
-  test-poller:
+  test-all:
 
     runs-on: ubuntu-latest
 
@@ -21,7 +21,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm test
-      env:
-        CI: true
+    - run: |
+        npm install
+        npm test
+    - run: cd ../scaler
+    - run: |
+        npm install
+        npm test
+    env:
+      CI: true


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
[`jobs.<job_id>.steps[*].run`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsrun)

the `cd ../` command is not working as intended.

See whether the two tests are same.
and see how you can work with multiple workdirs.